### PR TITLE
Use lazy collection to iterate over entries

### DIFF
--- a/src/Support/Sitemapamic.php
+++ b/src/Support/Sitemapamic.php
@@ -155,7 +155,7 @@ class Sitemapamic
         return collect(config('sitemapamic.defaults'))->mapWithKeys(function ($properties, $handle) {
             return [
                 $handle => function () use ($properties, $handle) {
-                    return Collection::findByHandle($handle)->queryEntries()->get()->filter(function (
+                    return Collection::findByHandle($handle)->queryEntries()->lazy(100)->filter(function (
                         \Statamic\Entries\Entry $entry
                     ) {
                         // same site? if site is different, remove


### PR DESCRIPTION
Solve #34 by iterating over entries using a lazy collection instead of loading all entries at once. Helps with performance and avoids crashes when generating sitemaps with thousands of entries.