### PR TITLE
fix for Undefined property: Statamic\Fieldtypes\Link\ArrayableLink::$url

### DIFF
--- a/src/Support/Sitemapamic.php
+++ b/src/Support/Sitemapamic.php
@@ -170,7 +170,7 @@ class Sitemapamic
 
                         // are we an external redirect?
                         // note the "dirty" trick to make the redirect a string (v4/5 has the ArrayableLink)
-                        if ($entry->blueprint()->handle() === 'link' && isset($entry->redirect) && URL::isExternal('' . $entry->redirect->url)) {
+                        if ($entry->blueprint()->handle() === 'link' && isset($entry->redirect) && URL::isExternal('' . $entry->redirect->url())) {
                             return false;
                         }
 


### PR DESCRIPTION
Pre 3.2.0 sitemap.xml generated fine.

3.3.0 + 3.4.0 throw Undefined property: Statamic\Fieldtypes\Link\ArrayableLink::$url when generating sitemap.xml

trying to access the url property on a ArrayableLink object using $entry->redirect->url, but in Statamic 5, the ArrayableLink class has a url() method instead of a url property